### PR TITLE
Updated header/licensing for savefile storage script

### DIFF
--- a/gamedata/scripts/dph_mcm_save_storage.script
+++ b/gamedata/scripts/dph_mcm_save_storage.script
@@ -1,46 +1,9 @@
 --[[
-------------------------------------------------------------
--- ---
--- MCM Savefile Storage
--- ---
--- Savefile-specific persistent MCM configuration storage
--- You are free to do with this file as you want, as long as you keep this header intact.
---
--- Version 1.0 for Anomaly 1.5.1 / MCM 1.3
--- By dph-hcl
-------------------------------------------------------------
+  DESCRIPTION: Savefile specific MCM-option storage. See ui_mcm.script for tutorial.
+  AUTHOR: dph-hcl
 
-USAGE
---
-Usually the only thing you need to do is call register_module(mod) from on_game_start() in your addon.
-The parameter "mod" here is the ID of the tree you return on_mcm_load() in your script.
-You may want to check for existence of "dph_mcm_save_storage" beforehand, unless you distribute this script with your addon.
-For example:
-
-    function on_mcm_load()
-        op = { id="example_example", ,gr={ ... } }
-        return op
-    end
-
-    function on_game_start()
-        if dph_mcm_save_storage then
-            dph_mcm_save_storage.register_module("example_example")
-        end
-    end
-
-And that's it. All config options inside that tree are now saved/loaded with the players savefile.
-You can also save only a subset of your options, or everything in a collection by passing the correct path as parameter:
-For example:
-
-    -- this isn't any different than the above example,
-    -- but since "example_collection" is a collection name the path will match all options starting with example_collection/
-    dph_mcm_save_storage.register_module("example_collection")
-    -- this will match "example_option1" in the tree "example_example"
-    dph_mcm_save_storage.register_module("example_example/example_option1")
-    -- this will match everything in the tree "example_example" belonging to "example_collection"
-    dph_mcm_save_storage.register_module("example_collection/example_example")
-
-And so on. It'll simply use all options that match the path you pass register_module, regardless of its semantics.
+  CHANGES:
+    2021-08-02 by dph-hcl - Removed license/superfluous usage info from header
 ]]--
 
 local modules = {}


### PR DESCRIPTION
Removed license restrictions as well as superfluous tutorial from the files header.