### PR TITLE
Fix for compare_paths

### DIFF
--- a/gamedata/scripts/dph_mcm_save_storage.script
+++ b/gamedata/scripts/dph_mcm_save_storage.script
@@ -62,7 +62,7 @@ local function compare_paths(mt, pt)
     local mm = str_explode(m, "/")
     local pp = str_explode(p, "/")
     for i, seg in ipairs(mm) do
-        if (not pp[i]) or (not seg == pp[i]) then
+        if (not pp[i]) or (seg ~= pp[i]) then
             return false
         end
         return true


### PR DESCRIPTION
Fix for a bug in dph_mcm_save_storage that made it so if there's at least one module - it will store all mcm settings.